### PR TITLE
Organize documentation files into docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ VITE_DEBUG_MODE=true
 
 For technical details, development setup, and advanced configuration, see:
 
-**[📖 Technical Documentation](./TECHNICAL.md)** - Complete technical reference
+**[📖 Technical Documentation](./docs/TECHNICAL.md)** - Complete technical reference
 
 ## 📄 License
 

--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -123,9 +123,9 @@ Check the browser console for any environment-related errors.
 
 ### Getting Help
 
-- **Backend issues**: See [backend/ENVIRONMENT_SETUP.md](./backend/ENVIRONMENT_SETUP.md)
-- **Frontend issues**: See [chrome-extension/ENVIRONMENT.md](./chrome-extension/ENVIRONMENT.md)
-- **General issues**: Check the main [README.md](./README.md)
+- **Backend issues**: See [backend/ENVIRONMENT_SETUP.md](../backend/ENVIRONMENT_SETUP.md)
+- **Frontend issues**: See [chrome-extension/ENVIRONMENT.md](../chrome-extension/ENVIRONMENT.md)
+- **General issues**: Check the main [README.md](../README.md)
 
 ## 📚 Additional Resources
 

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -231,19 +231,19 @@ For more detailed information, see the following documentation:
 
 ### Setup & Configuration
 - [Environment Setup Guide](./ENVIRONMENT_SETUP.md) - Comprehensive setup instructions
-- [Backend Environment Setup](./backend/ENVIRONMENT_SETUP.md) - Backend-specific configuration
-- [Chrome Extension Environment](./chrome-extension/ENVIRONMENT.md) - Extension configuration
+- [Backend Environment Setup](../backend/ENVIRONMENT_SETUP.md) - Backend-specific configuration
+- [Chrome Extension Environment](../chrome-extension/ENVIRONMENT.md) - Extension configuration
 
 ### Features & Usage
-- [MCP Integration Guide](./backend/MCP_INTEGRATION_README.md) - Model Context Protocol setup and usage
-- [Turbo Mode Documentation](./chrome-extension/TURBO_MODE_README.md) - Multi-model comparison feature
-- [Screenshot Capture Guide](./chrome-extension/SCREENSHOT_README.md) - Screen capture functionality
-- [Settings Management](./chrome-extension/SETTINGS_README.md) - Extension settings and preferences
+- [MCP Integration Guide](../backend/MCP_INTEGRATION_README.md) - Model Context Protocol setup and usage
+- [Turbo Mode Documentation](../chrome-extension/TURBO_MODE_README.md) - Multi-model comparison feature
+- [Screenshot Capture Guide](../chrome-extension/SCREENSHOT_README.md) - Screen capture functionality
+- [Settings Management](../chrome-extension/SETTINGS_README.md) - Extension settings and preferences
 
 ### Development & Testing
-- [Backend README](./backend/README.md) - Backend development guide
-- [Chrome Extension README](./chrome-extension/README.md) - Extension development guide
-- [Chat Sessions](./backend/CHAT_SESSIONS_README.md) - Session management system
+- [Backend README](../backend/README.md) - Backend development guide
+- [Chrome Extension README](../chrome-extension/README.md) - Extension development guide
+- [Chat Sessions](../backend/CHAT_SESSIONS_README.md) - Session management system
 
 ## 🤝 Contributing
 
@@ -264,4 +264,4 @@ For more detailed information, see the following documentation:
 
 ## 📄 License
 
-MIT License - see the [LICENSE](./LICENSE) file for details.
+MIT License - see the [LICENSE](../LICENSE) file for details.


### PR DESCRIPTION
Move markdown files into a new `docs` folder and update all affected links to centralize documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5ad83c8-a572-4a9d-b0bc-c986dc457c78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5ad83c8-a572-4a9d-b0bc-c986dc457c78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

