### PR TITLE
test(uiStore): achieve 100% store coverage by covering setTestModalVisible

### DIFF
--- a/chrome-extension/src/tests/stores/uiStore.test.js
+++ b/chrome-extension/src/tests/stores/uiStore.test.js
@@ -208,6 +208,23 @@ describe('UIStore', () => {
       });
     });
 
+    describe('setTestModalVisible', () => {
+      it('should show test modal', () => {
+        const { setTestModalVisible } = useUIStore.getState();
+        setTestModalVisible(true);
+        const state = useUIStore.getState();
+        expect(state.testModalVisible).toBe(true);
+      });
+
+      it('should hide test modal', () => {
+        const { setTestModalVisible } = useUIStore.getState();
+        setTestModalVisible(true);
+        setTestModalVisible(false);
+        const state = useUIStore.getState();
+        expect(state.testModalVisible).toBe(false);
+      });
+    });
+
     describe('setCurrentSelection', () => {
       it('should update current selection', () => {
         const { setCurrentSelection } = useUIStore.getState();
@@ -620,6 +637,7 @@ describe('UIStore', () => {
           setSettingsModalVisible,
           setHelpModalVisible,
           setForceConfigModalVisible,
+          setTestModalVisible,
           setCurrentSelection,
           addSelectedModel,
           setIsScreenshotMode,
@@ -640,6 +658,7 @@ describe('UIStore', () => {
         setSettingsModalVisible(true);
         setHelpModalVisible(true);
         setForceConfigModalVisible(true);
+        setTestModalVisible(true);
         setCurrentSelection({ text: 'test' });
         addSelectedModel('gpt-4');
         setIsScreenshotMode(true);
@@ -662,6 +681,7 @@ describe('UIStore', () => {
         expect(state.settingsModalVisible).toBe(false);
         expect(state.helpModalVisible).toBe(false);
         expect(state.forceConfigModalVisible).toBe(false);
+        expect(state.testModalVisible).toBe(false);
         expect(state.currentSelection).toBe(null);
         expect(state.selectedModels).toEqual([]);
         expect(state.isScreenshotMode).toBe(false);


### PR DESCRIPTION
## Summary
- Add tests for `setTestModalVisible` in `uiStore`
- Verify `testModalVisible` resets in `resetUIState`
- Confirm 100% line/function/branch coverage for store files via `npm run test:stores:coverage`

## Test plan
- Run `npm run test:stores:coverage`
- Verify coverage report shows 100% for `src/stores/uiStore.js` and `src/stores/chatStore.js`

## Notes
- Based on uncovered analysis in `chrome-extension/uncovered-analysis.json`