### PR TITLE
Increase store coverage to 100% (uiStore)

### DIFF
--- a/chrome-extension/src/tests/stores/uiStore.test.js
+++ b/chrome-extension/src/tests/stores/uiStore.test.js
@@ -208,6 +208,27 @@ describe('UIStore', () => {
       });
     });
 
+    describe('setTestModalVisible', () => {
+      it('should show test modal', () => {
+        const { setTestModalVisible } = useUIStore.getState();
+
+        setTestModalVisible(true);
+
+        const state = useUIStore.getState();
+        expect(state.testModalVisible).toBe(true);
+      });
+
+      it('should hide test modal', () => {
+        const { setTestModalVisible } = useUIStore.getState();
+
+        setTestModalVisible(true);
+        setTestModalVisible(false);
+
+        const state = useUIStore.getState();
+        expect(state.testModalVisible).toBe(false);
+      });
+    });
+
     describe('setCurrentSelection', () => {
       it('should update current selection', () => {
         const { setCurrentSelection } = useUIStore.getState();


### PR DESCRIPTION
## Summary
- Add missing tests for `setTestModalVisible` in `src/tests/stores/uiStore.test.js`
- Achieves 100% line/function/branch coverage for `src/stores/uiStore.js`

## Details
- Covered both show and hide paths for `testModalVisible`
- Verified via `npm run test:stores:coverage`

## Test plan
- [x] Run `npm run test:stores:coverage` locally in CI runner
- [x] Confirm coverage report shows 100% for `uiStore.js` and other stores