### PR TITLE
Test coverage: stores at 100% (uiStore + chatStore)

### DIFF
--- a/chrome-extension/src/tests/stores/uiStore.test.js
+++ b/chrome-extension/src/tests/stores/uiStore.test.js
@@ -208,6 +208,23 @@ describe('UIStore', () => {
       });
     });
 
+    describe('setTestModalVisible', () => {
+      it('should show test modal', () => {
+        const { setTestModalVisible } = useUIStore.getState();
+        setTestModalVisible(true);
+        const state = useUIStore.getState();
+        expect(state.testModalVisible).toBe(true);
+      });
+
+      it('should hide test modal', () => {
+        const { setTestModalVisible } = useUIStore.getState();
+        setTestModalVisible(true);
+        setTestModalVisible(false);
+        const state = useUIStore.getState();
+        expect(state.testModalVisible).toBe(false);
+      });
+    });
+
     describe('setCurrentSelection', () => {
       it('should update current selection', () => {
         const { setCurrentSelection } = useUIStore.getState();
@@ -620,6 +637,7 @@ describe('UIStore', () => {
           setSettingsModalVisible,
           setHelpModalVisible,
           setForceConfigModalVisible,
+          setTestModalVisible,
           setCurrentSelection,
           addSelectedModel,
           setIsScreenshotMode,
@@ -640,6 +658,7 @@ describe('UIStore', () => {
         setSettingsModalVisible(true);
         setHelpModalVisible(true);
         setForceConfigModalVisible(true);
+        setTestModalVisible(true);
         setCurrentSelection({ text: 'test' });
         addSelectedModel('gpt-4');
         setIsScreenshotMode(true);
@@ -662,6 +681,7 @@ describe('UIStore', () => {
         expect(state.settingsModalVisible).toBe(false);
         expect(state.helpModalVisible).toBe(false);
         expect(state.forceConfigModalVisible).toBe(false);
+        expect(state.testModalVisible).toBe(false);
         expect(state.currentSelection).toBe(null);
         expect(state.selectedModels).toEqual([]);
         expect(state.isScreenshotMode).toBe(false);


### PR DESCRIPTION
## Summary
- Achieved 100% line/function/branch coverage for store files (`src/stores/**/*.js`).
- Addressed the last uncovered line in `src/stores/uiStore.js` (setter for `testModalVisible`).

## What changed
- Updated `src/tests/stores/uiStore.test.js` to include comprehensive tests for `setTestModalVisible` and included assertions for `testModalVisible` in the `resetUIState` flow.
- Verified coverage with `npm run test:stores:coverage` which reports 100% across `uiStore.js` and `chatStore.js`.

## Evidence
- Local run in the GitHub Actions runner:
```
% Coverage report from v8
--------------|---------|----------|---------|---------|-------------------
All files     |     100 |      100 |     100 |     100 |
 chatStore.js |     100 |      100 |     100 |     100 |
 uiStore.js   |     100 |      100 |     100 |     100 |
--------------|---------|----------|---------|---------|-------------------
```

## Reasoning
- The uncovered analysis (`uncovered-analysis.json`) identified line 86 in `src/stores/uiStore.js` as uncovered: `state.testModalVisible = visible;`.
- Existing tests covered all other modal setters; we followed the established pattern to add symmetrical tests for the test modal.
- We also asserted that `resetUIState` resets `testModalVisible` to `false` to exercise that path.

## How to validate
1. Run `npm ci` (if needed) and ensure `vitest` is available.
2. Execute `npm run test:stores:coverage`.
3. Confirm coverage results are 100% for stores.

## Notes
- No production code changes; tests only.
- No new files added; only modified existing test file per requirements.